### PR TITLE
Relax dependency on Faraday and warn when using known problematic versions

### DIFF
--- a/lib/3scale/core.rb
+++ b/lib/3scale/core.rb
@@ -1,6 +1,14 @@
 require 'uri'
 require 'json'
 require 'faraday'
+require 'net/http/persistent'
+
+# Warn that Faraday < 0.13 and Net::HTTP::Persistent >= 3.0.0 don't mix well
+if Faraday::VERSION =~ /0\.([0-9]|1[012])\.\d+/ &&
+    Net::HTTP::Persistent::VERSION =~ /^[^012]\.\d+\.\d+/
+  warn 'The combination of faraday < 0.13 and net-http-persistent 3.0+ is ' \
+    'known to have issues. See https://github.com/lostisland/faraday/issues/617'
+end
 
 require '3scale/core/version'
 require '3scale/core/logger'

--- a/pisoni.gemspec
+++ b/pisoni.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
   s.description = 'Client for the Apisonator internal API for model data.'
   s.license     = 'Apache-2.0'
 
-  s.add_dependency 'faraday', '~> 0.13.1'
-  s.add_dependency 'json', '~> 1.8.1'
-  s.add_dependency 'injectedlogger', '~> 0.0.13'
+  s.add_dependency 'faraday', '>= 0.9.1'
+  s.add_dependency 'json', '>= 1.8.1'
+  s.add_dependency 'injectedlogger', '>= 0.0.13'
   s.add_dependency 'net-http-persistent'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
This relaxes dependencies in the gemspec, with especial treatment for the Faraday gem, for which we know there are versions that don't work well with recent versions of net-http-persistent.

A warning is now emitted when a bad combination is detected. /cc @hallelujah 