### PR TITLE
Small cleanups

### DIFF
--- a/lib/3scale/core/logger.rb
+++ b/lib/3scale/core/logger.rb
@@ -5,7 +5,7 @@ module ThreeScale
     module Logger
       InjectedLogger.use(:error, :info, :debug) {}
       InjectedLogger.after_injection do |logger|
-        logger.prefix = '[core]' unless logger.prefix
+        logger.prefix = '[pisoni]' unless logger.prefix
       end
     end
   end

--- a/lib/3scale/core/service_error.rb
+++ b/lib/3scale/core/service_error.rb
@@ -14,9 +14,9 @@ module ThreeScale
         result = api_do_get(options,
                             { uri: service_errors_uri(service_id),
                               prefix: '',
-                              rprefix: :errors }) do |result|
-          if result[:response].status == 400 &&
-              result[:response_json][:error] == 'per_page needs to be > 0'
+                              rprefix: :errors }) do |res|
+          if res[:response].status == 400 &&
+              res[:response_json][:error] == 'per_page needs to be > 0'
             raise InvalidPerPage.new
           end
           true

--- a/lib/3scale/core/transaction.rb
+++ b/lib/3scale/core/transaction.rb
@@ -12,8 +12,8 @@ module ThreeScale
 
       def self.load_all(service_id)
         result = api_do_get({}, { uri: transactions_uri(service_id),
-                                  rprefix: :transactions })  do |result|
-          return nil if result[:response].status == 404
+                                  rprefix: :transactions })  do |res|
+          return nil if res[:response].status == 404
           true
         end
 

--- a/lib/3scale/core/utilization.rb
+++ b/lib/3scale/core/utilization.rb
@@ -13,8 +13,8 @@ module ThreeScale
       def self.load(service_id, app_id)
         result = api_do_get({},
                             uri: utilization_uri(service_id, app_id),
-                            rprefix: :utilization) do |result|
-          return nil if result[:response].status == 404
+                            rprefix: :utilization) do |res|
+          return nil if res[:response].status == 404
           true
         end
 


### PR DESCRIPTION
- Output logs with `[pisoni]` instead of `[core]`.
- Fix three harmless warnings about shadowing outer variables from a block.