### PR TITLE
service: add state attr to Service class

### DIFF
--- a/lib/3scale/core/service.rb
+++ b/lib/3scale/core/service.rb
@@ -3,7 +3,7 @@ module ThreeScale
     class Service < APIClient::Resource
       attributes :provider_key, :id, :backend_version, :referrer_filters_required,
                  :user_registration_required, :default_user_plan_id,
-                 :default_user_plan_name, :default_service
+                 :default_user_plan_name, :default_service, :state
 
       class << self
         def load_by_id(service_id)

--- a/lib/3scale/core/service.rb
+++ b/lib/3scale/core/service.rb
@@ -66,6 +66,19 @@ module ThreeScale
         end
       end
 
+      def initialize(attributes = {})
+        @state = :active
+        super(attributes)
+      end
+
+      def activate
+        self.state = :active
+      end
+
+      def deactivate
+        self.state = :suspended
+      end
+
       def referrer_filters_required?
         @referrer_filters_required
       end
@@ -74,8 +87,19 @@ module ThreeScale
         @user_registration_required
       end
 
+      def active?
+        state == :active
+      end
+
       def save!
         self.class.save! attributes
+      end
+
+      private
+
+      def state=(value)
+        # only :active or nil will be considered as :active
+        @state = value.nil? || value.to_sym == :active ? :active : :suspended
       end
     end
   end


### PR DESCRIPTION
Issue defined at https://github.com/3scale/apisonator/issues/34

Disable service:

```
require 'pisoni'

ENV['THREESCALE_CORE_INTERNAL_API'] = nil
ThreeScale::Core.url = "http://myhost:myport"
ThreeScale::Core.username = "username_key"
ThreeScale::Core.password = "password_key"

service_id = "SVC_A"
service = ThreeScale::Core::Service.load_by_id(service_id)

service.deactivate
service.save!
```

Activate service:
```
require 'pisoni'

ENV['THREESCALE_CORE_INTERNAL_API'] = nil
ThreeScale::Core.url = "http://myhost:myport"
ThreeScale::Core.username = "username_key"
ThreeScale::Core.password = "password_key"

service_id = "SVC_A"
service = ThreeScale::Core::Service.load_by_id(service_id)

service.activate
service.save!
```

Activation status can be queried
```
require 'pisoni'

ENV['THREESCALE_CORE_INTERNAL_API'] = nil
ThreeScale::Core.url = "http://myhost:myport"
ThreeScale::Core.username = "username_key"
ThreeScale::Core.password = "password_key"

service_id = "SVC_A"
service = ThreeScale::Core::Service.load_by_id(service_id)

puts service.active?
```

Requires apisonator >= 2.87.1
