### PR TITLE
Dockerfile.ci: upgrade rbenv4ci and point to new 3scale image repo

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM quay.io/unleashed/rbenv4ci-container:v0.2.0-centos
+FROM quay.io/3scale/rbenv4ci-container:v0.2.1-centos
 MAINTAINER Alejandro Martinez Ruiz <amr@redhat.com>
 
 RUN sudo yum upgrade -y \


### PR DESCRIPTION
This updates to the latest rbenv4ci images and uses the new 3scale repositories for code and images.

[rbenv4ci](https://github.com/3scale/rbenv4ci) and [rbenv4ci-container](https://github.com/3scale/rbenv4ci-container) now live at the 3scale organization @ github, and the images generated by the latter are posted @ [quay.io](https://quay.io/repository/3scale/rbenv4ci-container).