### PR TITLE
spec/service_spec: update deleting default service tests

### DIFF
--- a/spec/service_error_spec.rb
+++ b/spec/service_error_spec.rb
@@ -4,7 +4,8 @@ require_relative './private_endpoints/service_error'
 module ThreeScale
   module Core
     describe ServiceError do
-      let(:service_id) { '7575' }
+      let(:service_id) { '7575_service_error_spec' }
+      let(:provider_key) { 'foo_service_error_spec' }
       let(:non_existing_service_id) { service_id.to_i.succ.to_s }
 
       describe '.load_all' do
@@ -17,7 +18,7 @@ module ThreeScale
 
         before do
           Service.delete_by_id!(service_id)
-          Service.save!(provider_key: 'foo', id: service_id)
+          Service.save!(provider_key: provider_key, id: service_id)
           ServiceError.delete_all(service_id)
           ServiceError.save(service_id, error_messages)
         end
@@ -100,7 +101,7 @@ module ThreeScale
       describe '.delete_all' do
         before do
           Service.delete_by_id!(service_id)
-          Service.save!(provider_key: 'foo', id: service_id)
+          Service.save!(provider_key: provider_key, id: service_id)
           ServiceError.delete_all(service_id)
         end
 

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -6,10 +6,10 @@ module ThreeScale
       let(:default_service_id) { 7001 }
       let(:non_default_service_id) { default_service_id.succ }
       let(:non_existent_service_id) { non_default_service_id.succ }
-      let(:default_provider_key) { 'foo' }
-      let(:other_provider_key) { 'bazinga' }
-      let(:another_provider_key) { 'bar' }
-      let(:non_existent_provider_key) { 'bunga' }
+      let(:default_provider_key) { 'foo_service_spec' }
+      let(:other_provider_key) { 'bazinga_service_spec' }
+      let(:another_provider_key) { 'bar_service_spec' }
+      let(:non_existent_provider_key) { 'bunga_service_spec' }
 
       before do
         # We create a new service for our provider as the default, then
@@ -62,22 +62,21 @@ module ThreeScale
       end
 
       describe '.delete_by_id!' do
-        before do
-          Service.save! provider_key: default_provider_key,
-                        id: default_service_id,
-                        default_service: true
-        end
-
         it 'returns true if deleting a non-default service' do
           Service.save! provider_key: default_provider_key,
                         id: non_default_service_id
           Service.delete_by_id!(non_default_service_id).must_equal true
         end
 
-        it 'raises an exception when deleting a default service' do
+        it 'raises an exception when deleting a default service and not unique' do
+          Service.save! provider_key: default_provider_key, id: non_default_service_id
           lambda do
             Service.delete_by_id! default_service_id
           end.must_raise ServiceIsDefaultService
+        end
+
+        it 'returns true when deleting a default service and is unique for the provider' do
+          Service.delete_by_id!(default_service_id).must_equal true
         end
       end
 

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -6,11 +6,11 @@ module ThreeScale
     describe Transaction do
       before do
         Service.delete_by_id!(service_id)
-        Service.save!(provider_key: 'foo', id: service_id)
+        Service.save!(provider_key: 'foo_transaction_spec', id: service_id)
       end
 
       describe '.load_all' do
-        let(:service_id) { '7575' }
+        let(:service_id) { '7575_transaction_spec' }
         let(:non_existing_service_id) { service_id.to_i.succ.to_s }
 
         before do

--- a/spec/utilization_spec.rb
+++ b/spec/utilization_spec.rb
@@ -3,9 +3,9 @@ require_relative './spec_helper'
 module ThreeScale
   module Core
     describe Utilization do
-      let(:service_id) { '1001' }
+      let(:service_id) { '1001_utilization_spec' }
       let(:non_existing_service_id) { service_id.to_i.succ.to_s }
-      let(:provider_key) { 'foo' }
+      let(:provider_key) { 'foo_utilization_spec' }
 
       let(:app_id) { '2001' }
       let(:non_existing_app_id) { app_id.to_i.succ.to_s }


### PR DESCRIPTION
Deleting default service will fail only when not unique for a given provider_key