### PR TITLE
Require Ruby 2.3 (and update the base CI image)

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM quay.io/3scale/rbenv4ci-container:v0.2.1-centos
+FROM quay.io/3scale/rbenv4ci-container:v0.2.2-centos
 MAINTAINER Alejandro Martinez Ruiz <amr@redhat.com>
 
 RUN sudo yum upgrade -y \

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -8,7 +8,7 @@ RUN sudo yum upgrade -y \
     && sudo rm -rf /var/cache/yum
 
 # specify all versions to be installed, partial versions also understood
-ARG RUBY_VERSIONS="2.2 2.3"
+ARG RUBY_VERSIONS="2.3 2.6"
 RUN ruby_versions ${RUBY_VERSIONS}
 
 ARG APP_RUNTIME_DEPS

--- a/pisoni.gemspec
+++ b/pisoni.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |s|
 
   s.rdoc_options = ["--charset=UTF-8"]
 
-  s.required_ruby_version = '>= 2.2.4'
+  s.required_ruby_version = '>= 2.3.0'
 end


### PR DESCRIPTION
Ruby 2.2 is unsupported. This should have happened a long time ago. No known users remain on 2.2.

While at it we also update the dependency on rbenv4ci-container to 0.2.2 and test 2.3 and 2.6 in the CI.