### PR TITLE
Add support for app credentials with special chars (*, $, etc.)

### DIFF
--- a/lib/3scale/core/application.rb
+++ b/lib/3scale/core/application.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module ThreeScale
   module Core
     class Application < APIClient::Resource
@@ -16,12 +18,16 @@ module ThreeScale
       private_class_method :base_uri
 
       def self.app_uri(service_id, id)
-        "#{base_uri(service_id)}#{id}"
+        escaped_id = CGI::escape(id.to_s)
+
+        "#{base_uri(service_id)}#{escaped_id}"
       end
       private_class_method :app_uri
 
       def self.key_uri(service_id, key)
-        "#{base_uri(service_id)}key/#{key}"
+        escaped_key = CGI::escape(key)
+
+        "#{base_uri(service_id)}key/#{escaped_key}"
       end
       private_class_method :key_uri
 
@@ -71,7 +77,8 @@ module ThreeScale
 
       def self.save_id_by_key(service_id, user_key, id)
         raise ApplicationHasInconsistentData.new(id, user_key) if (service_id.nil? || id.nil? || user_key.nil? || service_id=="" || id=="" || user_key=="")
-        ret = api_do_put({}, uri: "#{app_uri(service_id, id)}/key/#{user_key}")
+        escaped_key = CGI::escape(user_key)
+        ret = api_do_put({}, uri: "#{app_uri(service_id, id)}/key/#{escaped_key}")
         ret[:ok]
       end
 

--- a/lib/3scale/core/application_key.rb
+++ b/lib/3scale/core/application_key.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module ThreeScale
   module Core
     class ApplicationKey < APIClient::Resource
@@ -25,8 +27,10 @@ module ThreeScale
       end
       private_class_method :base_uri
 
-      def self.application_key_uri(service_id, application_id, value = nil)
-        "#{base_uri(service_id, application_id)}#{value}"
+      def self.application_key_uri(service_id, application_id, value = '')
+        escaped_value = CGI::escape(value)
+
+        "#{base_uri(service_id, application_id)}#{escaped_value}"
       end
       private_class_method :application_key_uri
     end

--- a/spec/application_key_spec.rb
+++ b/spec/application_key_spec.rb
@@ -75,47 +75,37 @@ module ThreeScale
       end
 
       describe '.delete' do
+        let(:service_id) { 300 }
+        let(:app_id) { 200 }
+        let(:key) { 'foo' }
+
+        before do
+          Application.save service_id: service_id, id: app_id, state: 'suspended',
+                           plan_id: '3066', plan_name: 'crappy', redirect_url: 'blah'
+        end
+
         describe 'with an existing application key' do
-          let(:service_id) { 300 }
-          let(:app_id)     { 200 }
-          let(:value)      { "foo" }
-
           before do
-            Application.save service_id: service_id, id: app_id, state: 'suspended',
-                             plan_id: '3066', plan_name: 'crappy', redirect_url: 'blah'
-
-            ApplicationKey.save(service_id, app_id, value)
+            ApplicationKey.save(service_id, app_id, key)
           end
 
           it 'returns true' do
-            ApplicationKey.delete(service_id, app_id, value).must_equal true
+            ApplicationKey.delete(service_id, app_id, key).must_equal true
           end
         end
 
         describe 'with a non-existing application key' do
-          let(:service_id) { 300 }
-          let(:app_id)     { 500 }
-          let(:value)      { "nonexistingkey" }
+          let(:key) { 'non_existing_key' }
 
-          before do
-            Application.save service_id: service_id, id: app_id, state: 'suspended',
-                             plan_id: '3066', plan_name: 'crappy', redirect_url: 'blah'
-          end
-
-          it 'returns true' do
-            ApplicationKey.delete(service_id, app_id, value).must_equal false
+          it 'returns false' do
+            ApplicationKey.delete(service_id, app_id, key).must_equal false
           end
         end
 
         describe 'with a key that contains special chars (*, _, etc.)' do
-          let(:service_id) { 300 }
-          let(:app_id)     { 500 }
-          let(:key)        { '#$*' }
+          let(:key_with_special_chars) { '#$*' }
 
           before do
-            Application.save service_id: service_id, id: app_id, state: 'suspended',
-                             plan_id: '3066', plan_name: 'crappy', redirect_url: 'blah'
-
             ApplicationKey.save(service_id, app_id, key)
           end
 

--- a/spec/application_key_spec.rb
+++ b/spec/application_key_spec.rb
@@ -57,6 +57,21 @@ module ThreeScale
           application_key.must_be_kind_of ApplicationKey
           application_key.value.must_equal value
         end
+
+        describe 'with a key that contains special chars (*, _, etc.)' do
+          let(:key) { '#$*' }
+
+          before do
+            ApplicationKey.delete(service_id, app_id, key)
+          end
+
+          it 'saves it correctly' do
+            application_key = ApplicationKey.save(service_id, app_id, key)
+
+            application_key.must_be_kind_of ApplicationKey
+            application_key.value.must_equal key
+          end
+        end
       end
 
       describe '.delete' do
@@ -89,6 +104,23 @@ module ThreeScale
 
           it 'returns true' do
             ApplicationKey.delete(service_id, app_id, value).must_equal false
+          end
+        end
+
+        describe 'with a key that contains special chars (*, _, etc.)' do
+          let(:service_id) { 300 }
+          let(:app_id)     { 500 }
+          let(:key)        { '#$*' }
+
+          before do
+            Application.save service_id: service_id, id: app_id, state: 'suspended',
+                             plan_id: '3066', plan_name: 'crappy', redirect_url: 'blah'
+
+            ApplicationKey.save(service_id, app_id, key)
+          end
+
+          it 'returns true' do
+            ApplicationKey.delete(service_id, app_id, key).must_equal true
           end
         end
       end

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -44,6 +44,20 @@ module ThreeScale
             Application.load(1999, 7999).must_be_nil
           end
         end
+
+        describe 'with an app ID that contains special characters' do
+          let(:service_id) { 2001 }
+          let(:app_id) { '#$*' }
+
+          before do
+            Application.save service_id: service_id, id: app_id, state: 'suspended',
+                             plan_id: '3066', plan_name: 'crappy', redirect_url: 'blah'
+          end
+
+          it 'returns an app with the correct ID' do
+            Application.load(service_id, app_id).id.must_equal app_id
+          end
+        end
       end
 
       describe '.delete' do
@@ -71,6 +85,20 @@ module ThreeScale
 
           it 'returns false when deleting an application with missing service id' do
             Application.delete(1999, 8011).must_equal false
+          end
+        end
+
+        describe 'with an app ID that contains special characters' do
+          let(:service_id) { 2001 }
+          let(:app_id) { '#$*' }
+
+          before do
+            Application.save service_id: service_id, id: app_id, state: 'suspended',
+                             plan_id: '3066', plan_name: 'crappy', redirect_url: 'blah'
+          end
+
+          it 'returns true when deleting an existing app' do
+            Application.delete(service_id, app_id).must_equal true
           end
         end
       end
@@ -124,6 +152,22 @@ module ThreeScale
             lambda do
               Application.save(attrs)
             end.must_raise KeyError # minitest wont catch parent exceptions :/
+          end
+        end
+
+        describe 'with an app ID that contains special characters' do
+          let(:service_id) { 2001 }
+          let(:app_id) { '#$*' }
+
+          before do
+            Application.delete(service_id, app_id)
+          end
+
+          it 'returns an object with the correct ID' do
+            app = Application.save service_id: service_id, id: app_id, state: 'suspended',
+                                   plan_id: '3066', plan_name: 'crappy', redirect_url: 'blah'
+
+            app.id.must_equal app_id
           end
         end
       end
@@ -226,6 +270,8 @@ module ThreeScale
       end
 
       describe 'by_key' do
+        let(:key_with_special_chars) { '#$*' }
+
         before do
           Application.save_id_by_key(2001, 'a_key', 8011)
         end
@@ -233,6 +279,16 @@ module ThreeScale
         describe '.load_id_by_key' do
           it 'returns the app ID linked to the specified service and key' do
             Application.load_id_by_key(2001, 'a_key').must_equal '8011'
+          end
+
+          describe 'with a key that contains special chars (*, _, etc.)' do
+            before do
+              Application.save_id_by_key(2001, key_with_special_chars, 8011)
+            end
+
+            it 'returns the correct app ID' do
+              Application.load_id_by_key(2001, key_with_special_chars).must_equal '8011'
+            end
           end
         end
 
@@ -244,6 +300,17 @@ module ThreeScale
             # clean up this key
             Application.delete_id_by_key(2001, 'another_key')
           end
+
+          describe 'with a key that contains special chars (*, _, etc.)' do
+            after do
+              Application.delete_id_by_key(2001, key_with_special_chars)
+            end
+
+            it 'changes the key linked to the app ID and service' do
+              Application.save_id_by_key(2001, key_with_special_chars, 8011).must_equal true
+              Application.load_id_by_key(2001, key_with_special_chars).must_equal '8011'
+            end
+          end
         end
 
         describe '.delete_id_by_key' do
@@ -251,6 +318,17 @@ module ThreeScale
             Application.load_id_by_key(2001, 'a_key').must_equal '8011'
             Application.delete_id_by_key(2001, 'a_key')
             Application.load_id_by_key(2001, 'a_key').must_be_nil
+          end
+
+          describe 'with a key that contains special chars (*, _, etc.)' do
+            before do
+              Application.save_id_by_key(2001, key_with_special_chars, 8011)
+            end
+
+            it 'deletes the app' do
+              Application.delete_id_by_key(2001, key_with_special_chars)
+              Application.load_id_by_key(2001, key_with_special_chars).must_be_nil
+            end
           end
         end
       end

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -270,64 +270,69 @@ module ThreeScale
       end
 
       describe 'by_key' do
+        let(:key) { 'a_key' }
         let(:key_with_special_chars) { '#$*' }
+        let(:service_id) { 2001 }
+        let(:app_id) { 8011 }
 
         before do
-          Application.save_id_by_key(2001, 'a_key', 8011)
+          Application.save_id_by_key(service_id, key, app_id)
         end
 
         describe '.load_id_by_key' do
           it 'returns the app ID linked to the specified service and key' do
-            Application.load_id_by_key(2001, 'a_key').must_equal '8011'
+            Application.load_id_by_key(service_id, key).must_equal app_id.to_s
           end
 
           describe 'with a key that contains special chars (*, _, etc.)' do
             before do
-              Application.save_id_by_key(2001, key_with_special_chars, 8011)
+              Application.save_id_by_key(service_id, key_with_special_chars, app_id)
             end
 
             it 'returns the correct app ID' do
-              Application.load_id_by_key(2001, key_with_special_chars).must_equal '8011'
+              Application.load_id_by_key(service_id, key_with_special_chars).must_equal app_id.to_s
             end
           end
         end
 
         describe '.save_id_by_key' do
+          let(:another_key) { key.succ }
+
           it 'changes the key linked to the app ID and service' do
-            Application.load_id_by_key(2001, 'another_key').must_be_nil
-            Application.save_id_by_key(2001, 'another_key', 8011).must_equal true
-            Application.load_id_by_key(2001, 'another_key').must_equal '8011'
+            Application.load_id_by_key(service_id, another_key).must_be_nil
+            Application.save_id_by_key(service_id, another_key, app_id).must_equal true
+            Application.load_id_by_key(service_id, another_key).must_equal app_id.to_s
             # clean up this key
-            Application.delete_id_by_key(2001, 'another_key')
+            Application.delete_id_by_key(service_id, another_key)
           end
 
           describe 'with a key that contains special chars (*, _, etc.)' do
             after do
-              Application.delete_id_by_key(2001, key_with_special_chars)
+              Application.delete_id_by_key(service_id, key_with_special_chars)
             end
 
             it 'changes the key linked to the app ID and service' do
-              Application.save_id_by_key(2001, key_with_special_chars, 8011).must_equal true
-              Application.load_id_by_key(2001, key_with_special_chars).must_equal '8011'
+              Application.save_id_by_key(service_id, key_with_special_chars, app_id).must_equal true
+              Application.load_id_by_key(service_id, key_with_special_chars).must_equal app_id.to_s
             end
           end
         end
 
         describe '.delete_id_by_key' do
           it 'deletes the key linked to the app ID and service' do
-            Application.load_id_by_key(2001, 'a_key').must_equal '8011'
-            Application.delete_id_by_key(2001, 'a_key')
-            Application.load_id_by_key(2001, 'a_key').must_be_nil
+            Application.load_id_by_key(service_id, key).must_equal app_id.to_s
+            Application.delete_id_by_key(service_id, key)
+            Application.load_id_by_key(service_id, key).must_be_nil
           end
 
           describe 'with a key that contains special chars (*, _, etc.)' do
             before do
-              Application.save_id_by_key(2001, key_with_special_chars, 8011)
+              Application.save_id_by_key(service_id, key_with_special_chars, app_id)
             end
 
             it 'deletes the app' do
-              Application.delete_id_by_key(2001, key_with_special_chars)
-              Application.load_id_by_key(2001, key_with_special_chars).must_be_nil
+              Application.delete_id_by_key(service_id, key_with_special_chars)
+              Application.load_id_by_key(service_id, key_with_special_chars).must_be_nil
             end
           end
         end


### PR DESCRIPTION
Reference : https://issues.jboss.org/browse/THREESCALE-1451

This PR adds support for app credentials (app_id, app_key, user_key) with special characters ($, *, etc.). Those characters need to be url-encoded when they are included in a URL, but they were not.

Apart from that, I added a couple of commits that clean up a bit the tests related with this PR.