### PR TITLE
Adapt "Service.delete_stats" to the new implementation

### DIFF
--- a/lib/3scale/core/service.rb
+++ b/lib/3scale/core/service.rb
@@ -41,8 +41,11 @@ module ThreeScale
           save! id: service_id, default_service: true
         end
 
-        def delete_stats(service_id, delete_job)
-          api_delete(delete_job, uri: "#{service_uri(service_id)}/stats", prefix: '')
+        # Deletes all the stats for the given service.
+        # Note: delete_job is no longer needed. It's kept to avoid breaking
+        # compatibility.
+        def delete_stats(service_id, _delete_job)
+          api_delete({}, uri: "#{service_uri(service_id)}/stats", prefix: '')
         end
 
         private

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -232,8 +232,14 @@ module ThreeScale
           }
         end
 
-        describe 'with valid job' do
+        describe 'with a service ID' do
           it 'does not raise error' do
+            Service.delete_stats(default_service_id, nil).must_equal true
+          end
+        end
+
+        describe 'with a deprecated delete_job param' do
+          it 'ignores it without raising error' do
             Service.delete_stats(default_service_id, delete_job).must_equal true
           end
         end


### PR DESCRIPTION
Adapts `Service.delete_stats` to the new implementation in Apisonator (https://github.com/3scale/apisonator/pull/143).