### PR TITLE
Delete unused Service attrs related with end-users functionality

### DIFF
--- a/lib/3scale/core/service.rb
+++ b/lib/3scale/core/service.rb
@@ -2,8 +2,7 @@ module ThreeScale
   module Core
     class Service < APIClient::Resource
       attributes :provider_key, :id, :backend_version, :referrer_filters_required,
-                 :user_registration_required, :default_user_plan_id,
-                 :default_user_plan_name, :default_service, :state
+                 :default_service, :state
 
       class << self
         def load_by_id(service_id)
@@ -83,10 +82,6 @@ module ThreeScale
 
       def referrer_filters_required?
         @referrer_filters_required
-      end
-
-      def user_registration_required?
-        @user_registration_required
       end
 
       def active?

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -26,8 +26,6 @@ module ThreeScale
                                 id: default_service_id,
                                 referrer_filters_required: true,
                                 backend_version: 'oauth',
-                                default_user_plan_id: 15,
-                                default_user_plan_name: 'test name',
                                 default_service: true
         raise unless service.default_service
 
@@ -47,10 +45,7 @@ module ThreeScale
             service.provider_key.must_equal default_provider_key
             service.id.must_equal default_service_id.to_s
             service.referrer_filters_required?.must_equal true
-            service.user_registration_required?.must_equal true
             service.backend_version.must_equal 'oauth'
-            service.default_user_plan_id.must_equal '15'
-            service.default_user_plan_name.must_equal 'test name'
           end
         end
 


### PR DESCRIPTION
The end-users functionality was removed some time ago, so these attributes can be safely deleted.
Related https://github.com/3scale/apisonator/pull/277