### PR TITLE
Escape app id for key urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Notable changes to Pisoni will be tracked in this document.
 
+## 1.29.1 - 2023-11-30
+
+### Changed
+
+- Fixed the issue with updating/deleting keys for applications with special characters in the
+application IDs by escaping them. [#31](https://github.com/3scale/pisoni/pull/31)
+
 ## 1.29.0 - 2020-03-17
 
 ### Removed

--- a/lib/3scale/core/application.rb
+++ b/lib/3scale/core/application.rb
@@ -25,7 +25,7 @@ module ThreeScale
       private_class_method :app_uri
 
       def self.key_uri(service_id, key)
-        escaped_key = CGI::escape(key)
+        escaped_key = CGI::escape(key.to_s)
 
         "#{base_uri(service_id)}key/#{escaped_key}"
       end

--- a/lib/3scale/core/application_key.rb
+++ b/lib/3scale/core/application_key.rb
@@ -23,14 +23,12 @@ module ThreeScale
       end
 
       def self.base_uri(service_id, application_id)
-        "#{default_uri}#{service_id}/applications/#{application_id}/keys/"
+        "#{default_uri}#{service_id}/applications/#{CGI::escape(application_id.to_s)}/keys/"
       end
       private_class_method :base_uri
 
       def self.application_key_uri(service_id, application_id, value = '')
-        escaped_value = CGI::escape(value)
-
-        "#{base_uri(service_id, application_id)}#{escaped_value}"
+        "#{base_uri(service_id, application_id)}#{CGI::escape(value.to_s)}"
       end
       private_class_method :application_key_uri
     end

--- a/lib/3scale/core/version.rb
+++ b/lib/3scale/core/version.rb
@@ -1,5 +1,5 @@
 module ThreeScale
   module Core
-    VERSION = '1.29.0'
+    VERSION = '1.29.1'
   end
 end

--- a/spec/application_key_spec.rb
+++ b/spec/application_key_spec.rb
@@ -72,6 +72,22 @@ module ThreeScale
             application_key.value.must_equal key
           end
         end
+
+        describe 'with app ID that contains special characters ({, $, ? etc.)' do
+          let(:app_id) { 'abc{1}$3?' }
+          let(:key) { 'z#$*' }
+
+          before do
+            ApplicationKey.delete(service_id, app_id, key)
+          end
+
+          it 'saves it correctly' do
+            application_key = ApplicationKey.save(service_id, app_id, key)
+
+            application_key.must_be_kind_of ApplicationKey
+            application_key.value.must_equal key
+          end
+        end
       end
 
       describe '.delete' do


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/THREESCALE-9033

To run the test suite:
```
THREESCALE_CORE_INTERNAL_API=http://system_app:password@127.0.0.1:3001/internal bundle exec rake test
```

(or a different URL that corresponds to a locally running apisonator)