### PR TITLE
Fix utilization URL for special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Notable changes to Pisoni will be tracked in this document.
 
+## [Unreleased]
+
+### Changed
+
+- Fixed the issue with fetching utilization and managing referrer filters for applications with special characters in the
+  application IDs by escaping them. [#33](https://github.com/3scale/pisoni/pull/33)
+
 ## 1.29.1 - 2023-11-30
 
 ### Changed

--- a/docker/docker-compose.apisonator.yml
+++ b/docker/docker-compose.apisonator.yml
@@ -12,7 +12,7 @@ services:
     command:
       3scale_backend start -p 3000 -l "${APISONATOR_LOGFILE}"
     environment:
-      RACK_ENV: development
+      RACK_ENV: test
       APISONATOR_IAPI_USER: "${APISONATOR_IAPI_USER}"
       APISONATOR_IAPI_PASSWORD: "${APISONATOR_IAPI_PASSWORD}"
       APISONATOR_REDIS_URL: redis://redis:6379

--- a/lib/3scale/core/api_client/support.rb
+++ b/lib/3scale/core/api_client/support.rb
@@ -1,3 +1,5 @@
+require 'erb'
+
 module ThreeScale
   module Core
     module APIClient
@@ -36,6 +38,10 @@ module ThreeScale
           def default_prefix(prefix = nil)
             return @default_prefix ||= self.to_s.split(':').last.downcase.to_sym unless prefix
             @default_prefix = prefix
+          end
+
+          def url_encode(str)
+            ERB::Util.url_encode(str)
           end
 
           private

--- a/lib/3scale/core/application.rb
+++ b/lib/3scale/core/application.rb
@@ -1,5 +1,3 @@
-require 'cgi'
-
 module ThreeScale
   module Core
     class Application < APIClient::Resource
@@ -18,16 +16,12 @@ module ThreeScale
       private_class_method :base_uri
 
       def self.app_uri(service_id, id)
-        escaped_id = CGI::escape(id.to_s)
-
-        "#{base_uri(service_id)}#{escaped_id}"
+        "#{base_uri(service_id)}#{url_encode(id)}"
       end
       private_class_method :app_uri
 
       def self.key_uri(service_id, key)
-        escaped_key = CGI::escape(key.to_s)
-
-        "#{base_uri(service_id)}key/#{escaped_key}"
+        "#{base_uri(service_id)}key/#{url_encode(key)}"
       end
       private_class_method :key_uri
 
@@ -77,8 +71,7 @@ module ThreeScale
 
       def self.save_id_by_key(service_id, user_key, id)
         raise ApplicationHasInconsistentData.new(id, user_key) if (service_id.nil? || id.nil? || user_key.nil? || service_id=="" || id=="" || user_key=="")
-        escaped_key = CGI::escape(user_key)
-        ret = api_do_put({}, uri: "#{app_uri(service_id, id)}/key/#{escaped_key}")
+        ret = api_do_put({}, uri: "#{app_uri(service_id, id)}/key/#{url_encode(user_key)}")
         ret[:ok]
       end
 

--- a/lib/3scale/core/application_key.rb
+++ b/lib/3scale/core/application_key.rb
@@ -1,5 +1,3 @@
-require 'cgi'
-
 module ThreeScale
   module Core
     class ApplicationKey < APIClient::Resource
@@ -23,12 +21,12 @@ module ThreeScale
       end
 
       def self.base_uri(service_id, application_id)
-        "#{default_uri}#{service_id}/applications/#{CGI::escape(application_id.to_s)}/keys/"
+        "#{default_uri}#{service_id}/applications/#{url_encode(application_id)}/keys/"
       end
       private_class_method :base_uri
 
       def self.application_key_uri(service_id, application_id, value = '')
-        "#{base_uri(service_id, application_id)}#{CGI::escape(value.to_s)}"
+        "#{base_uri(service_id, application_id)}#{url_encode(value)}"
       end
       private_class_method :application_key_uri
     end

--- a/lib/3scale/core/application_referrer_filter.rb
+++ b/lib/3scale/core/application_referrer_filter.rb
@@ -25,7 +25,7 @@ module ThreeScale
       end
 
       def self.base_uri(service_id, application_id)
-        "#{default_uri}#{service_id}/applications/#{application_id}/referrer_filters"
+        "#{default_uri}#{service_id}/applications/#{url_encode(application_id)}/referrer_filters"
       end
       private_class_method :base_uri
     end

--- a/lib/3scale/core/utilization.rb
+++ b/lib/3scale/core/utilization.rb
@@ -6,7 +6,7 @@ module ThreeScale
       default_uri '/internal/services/'
 
       def self.utilization_uri(service_id, app_id)
-        "#{default_uri}#{service_id}/applications/#{app_id}/utilization/"
+        "#{default_uri}#{service_id}/applications/#{url_encode(app_id)}/utilization/"
       end
       private_class_method :utilization_uri
 

--- a/spec/application_key_spec.rb
+++ b/spec/application_key_spec.rb
@@ -59,7 +59,7 @@ module ThreeScale
         end
 
         describe 'with a key that contains special chars (*, _, etc.)' do
-          let(:key) { '#$*' }
+          let(:key) { SPECIAL_CHARACTERS }
 
           before do
             ApplicationKey.delete(service_id, app_id, key)
@@ -74,8 +74,8 @@ module ThreeScale
         end
 
         describe 'with app ID that contains special characters ({, $, ? etc.)' do
-          let(:app_id) { 'abc{1}$3?' }
-          let(:key) { 'z#$*' }
+          let(:app_id) { SPECIAL_CHARACTERS }
+          let(:key) { SPECIAL_CHARACTERS }
 
           before do
             ApplicationKey.delete(service_id, app_id, key)
@@ -119,7 +119,7 @@ module ThreeScale
         end
 
         describe 'with a key that contains special chars (*, _, etc.)' do
-          let(:key_with_special_chars) { '#$*' }
+          let(:key_with_special_chars) { SPECIAL_CHARACTERS }
 
           before do
             ApplicationKey.save(service_id, app_id, key)

--- a/spec/application_referrer_filter_spec.rb
+++ b/spec/application_referrer_filter_spec.rb
@@ -3,7 +3,7 @@ module ThreeScale
   module Core
     describe ApplicationReferrerFilter do
       let(:service_id) { 10 }
-      let(:app_id)     { 100 }
+      let(:app_id)     { SPECIAL_CHARACTERS }
       let(:filters) { %w(foo bar doopah) }
       let(:application) do
         { service_id: service_id,
@@ -24,6 +24,8 @@ module ThreeScale
       end
 
       describe '.load_all' do
+        subject { ApplicationReferrerFilter.load_all(service_id, app_id) }
+
         describe 'Getting all referrer filters' do
           let(:ref_filters)     { %w(foo bar) }
 
@@ -32,14 +34,13 @@ module ThreeScale
           end
 
           it 'returns a sorted list of filters' do
-            filters = ApplicationReferrerFilter.load_all(service_id, app_id)
-            filters.must_equal ref_filters.sort
+            subject.must_equal ref_filters.sort
           end
         end
 
         describe 'when there are no referrer filters' do
           it 'returns an empty list' do
-            ApplicationReferrerFilter.load_all(service_id, app_id).must_equal []
+            subject.must_equal []
           end
         end
       end

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -47,7 +47,7 @@ module ThreeScale
 
         describe 'with an app ID that contains special characters' do
           let(:service_id) { 2001 }
-          let(:app_id) { '#$*' }
+          let(:app_id) { SPECIAL_CHARACTERS }
 
           before do
             Application.save service_id: service_id, id: app_id, state: 'suspended',
@@ -90,7 +90,7 @@ module ThreeScale
 
         describe 'with an app ID that contains special characters' do
           let(:service_id) { 2001 }
-          let(:app_id) { '#$*' }
+          let(:app_id) { SPECIAL_CHARACTERS }
 
           before do
             Application.save service_id: service_id, id: app_id, state: 'suspended',
@@ -157,7 +157,7 @@ module ThreeScale
 
         describe 'with an app ID that contains special characters' do
           let(:service_id) { 2001 }
-          let(:app_id) { '#$*' }
+          let(:app_id) { SPECIAL_CHARACTERS }
 
           before do
             Application.delete(service_id, app_id)
@@ -271,7 +271,7 @@ module ThreeScale
 
       describe 'by_key' do
         let(:key) { 'a_key' }
-        let(:key_with_special_chars) { '#$*' }
+        let(:key_with_special_chars) { SPECIAL_CHARACTERS }
         let(:service_id) { 2001 }
         let(:app_id) { 8011 }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,5 @@ $:.unshift(File.dirname(__FILE__) + '/../lib')
 require 'minitest/autorun'
 require 'bundler/setup'
 Bundler.require(:default, :development, :test)
+
+SPECIAL_CHARACTERS = "! \"#$%&'()*+,-.:;<=>?@[]^_`{|}~\\/".freeze

--- a/spec/utilization_spec.rb
+++ b/spec/utilization_spec.rb
@@ -105,6 +105,16 @@ module ThreeScale
             Utilization.load(service_id, non_existing_app_id).must_be_nil
           end
         end
+
+        describe 'with an application ID with special characters' do
+          let(:app_id) { SPECIAL_CHARACTERS }
+
+          subject { Utilization.load(service_id, app_id) }
+
+          it 'gets expected results' do
+            subject.wont_be_empty
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This is related to [THREESCALE-9033](https://issues.redhat.com/browse/THREESCALE-9033).

Previously https://github.com/3scale/pisoni/pull/31 fixed the same issue for managing application keys.

This PR fixes it for utilization and referrer filters endpoints.