### PR TITLE
Fix dependencies

### DIFF
--- a/.env
+++ b/.env
@@ -9,4 +9,4 @@ APISONATOR_IAPI_USER=pisoni
 APISONATOR_IAPI_PASSWORD=p4ssw0rd
 # if you need all installed versions, use keyword all
 # if you need a few, use ie. TEST_RUBIES=2.2 2.3
-TEST_RUBIES=all
+TEST_RUBIES=2.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 Notable changes to Pisoni will be tracked in this document.
 
-## [Unreleased]
+## 1.30.0 - 2024-02-29
 
 ### Changed
 
 - Fixed the issue with fetching utilization and managing referrer filters for applications with special characters in the
   application IDs by escaping them. [#33](https://github.com/3scale/pisoni/pull/33)
+- Upgrade dependencies, specifically `faraday` and `json`, making Ruby 2.6 the minimum supported version. [#34](https://github.com/3scale/pisoni/pull/34)
 
 ## 1.29.1 - 2023-11-30
 

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -8,7 +8,7 @@ RUN sudo yum upgrade -y \
     && sudo rm -rf /var/cache/yum
 
 # specify all versions to be installed, partial versions also understood
-ARG RUBY_VERSIONS="2.3 2.6"
+ARG RUBY_VERSIONS="2.6"
 RUN ruby_versions ${RUBY_VERSIONS}
 
 ARG APP_RUNTIME_DEPS

--- a/lib/3scale/core.rb
+++ b/lib/3scale/core.rb
@@ -1,14 +1,7 @@
 require 'uri'
 require 'json'
 require 'faraday'
-require 'net/http/persistent'
-
-# Warn that Faraday < 0.13 and Net::HTTP::Persistent >= 3.0.0 don't mix well
-if Faraday::VERSION =~ /0\.([0-9]|1[012])\.\d+/ &&
-    Net::HTTP::Persistent::VERSION =~ /^[^012]\.\d+\.\d+/
-  warn 'The combination of faraday < 0.13 and net-http-persistent 3.0+ is ' \
-    'known to have issues. See https://github.com/lostisland/faraday/issues/617'
-end
+require 'faraday/net_http_persistent'
 
 require '3scale/core/version'
 require '3scale/core/logger'
@@ -56,7 +49,7 @@ module ThreeScale
         @password = uri.password
       end
 
-      @faraday.basic_auth(@username, @password) if @username || @password
+      @faraday.set_basic_auth(@username, @password) if @username || @password
       @faraday
     end
 

--- a/lib/3scale/core/api_client/operations.rb
+++ b/lib/3scale/core/api_client/operations.rb
@@ -106,7 +106,7 @@ module ThreeScale
             else
               Core.faraday.send method, uri, attributes.to_json
             end
-          rescue Faraday::Error::ClientError, SystemCallError => e
+          rescue Faraday::ClientError, SystemCallError => e
             raise ConnectionError, e
           end
           private :api_http

--- a/lib/3scale/core/version.rb
+++ b/lib/3scale/core/version.rb
@@ -1,5 +1,5 @@
 module ThreeScale
   module Core
-    VERSION = '1.29.1'
+    VERSION = '1.30.0'
   end
 end

--- a/pisoni.gemspec
+++ b/pisoni.gemspec
@@ -40,5 +40,5 @@ Gem::Specification.new do |s|
 
   s.rdoc_options = ["--charset=UTF-8"]
 
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.6.0'
 end

--- a/pisoni.gemspec
+++ b/pisoni.gemspec
@@ -18,12 +18,13 @@ Gem::Specification.new do |s|
   s.description = 'Client for the Apisonator internal API for model data.'
   s.license     = 'Apache-2.0'
 
-  s.add_dependency 'faraday', '>= 0.9.1'
-  s.add_dependency 'json', '>= 1.8.1'
-  s.add_dependency 'injectedlogger', '>= 0.0.13'
-  s.add_dependency 'net-http-persistent'
+  # faraday v2.9.0 removes support for Ruby 2.7, see https://github.com/lostisland/faraday/releases/tag/v2.9.0
+  s.add_runtime_dependency 'faraday', '~> 2.0', '<= 2.9'
+  s.add_runtime_dependency 'json', '~> 2.7', '>= 2.7.1'
+  s.add_runtime_dependency 'injectedlogger', '0.0.13'
+  s.add_runtime_dependency 'faraday-net_http_persistent', '~> 2.1'
 
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '~> 13.1'
 
   s.files         = `git ls-files`.split($/).reject do |f| [
                         %r{^\.[^\/]},


### PR DESCRIPTION
Fix the following issues:

1. Warnings on gem build:
```
WARNING:  open-ended dependency on faraday (>= 0.9.1) is not recommended
  if faraday is semantically versioned, use:
    add_runtime_dependency 'faraday', '~> 0.9', '>= 0.9.1'
WARNING:  open-ended dependency on json (>= 1.8.1) is not recommended
  if json is semantically versioned, use:
    add_runtime_dependency 'json', '~> 1.8', '>= 1.8.1'
WARNING:  open-ended dependency on injectedlogger (>= 0.0.13) is not recommended
  if injectedlogger is semantically versioned, use:
    add_runtime_dependency 'injectedlogger', '~> 0.0', '>= 0.0.13'
WARNING:  open-ended dependency on net-http-persistent (>= 0) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  open-ended dependency on rake (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
```

2. Warnings on staring the Rails server that uses pisoni as dependency:

```
Top level ::CompositeIO is deprecated, require 'multipart/post' and use `Multipart::Post::CompositeReadIO` instead!
Top level ::Parts is deprecated, require 'multipart/post' and use `Multipart::Post::Parts` instead!
```
reported in [THREESCALE-10603](https://issues.redhat.com/browse/THREESCALE-10603).
